### PR TITLE
Use https rather than http for image urls to avoid mixed (insecure) c…

### DIFF
--- a/Virtuoso-82-Special-Offers.ttl
+++ b/Virtuoso-82-Special-Offers.ttl
@@ -15,7 +15,7 @@
 	schema:price "249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-82-personal-WKS-WIN-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2019-04-virtuoso-82-personal-WKS-WIN#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-WIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-WIN.png> ;
 	skos:prefLabel "Virtuoso 8.2 Personal License For Windows (Workstation) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.2 Personal License  (expiring, 4 concurrent threads)" ;
 	schema:category "personal" ;
@@ -67,7 +67,7 @@ _:node1d7fijg99x1 oplpro:hasFamily <http://data.openlinksw.com/oplweb/product_fa
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-WIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-WIN.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease82x#this> ;
 	schema:name "Software License : Virtuoso 8.2 Personal License  (expiring, 4 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -98,7 +98,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-82-personal-WKS-LIN-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2019-04-virtuoso-82-personal-WKS-LIN#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-LIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-LIN.png> ;
 	skos:prefLabel "Virtuoso 8.2 Personal License For Linux (Workstation) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.2 Personal License  (expiring, 4 concurrent threads)" ;
 	schema:category "personal" ;
@@ -144,7 +144,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-LIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-LIN.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease82x#this> ;
 	schema:name "Software License : Virtuoso 8.2 Personal License  (expiring, 4 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -172,7 +172,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-82-personal-WKS-MAC-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2019-04-virtuoso-82-personal-WKS-MAC#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-MAC.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-MAC.png> ;
 	skos:prefLabel "Virtuoso 8.2 Personal License For macOS (Workstation) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.2 Personal License  (expiring, 4 concurrent threads)" ;
 	schema:category "personal" ;
@@ -218,7 +218,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-MAC.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-MAC.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease82x#this> ;
 	schema:name "Software License : Virtuoso 8.2 Personal License  (expiring, 4 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -246,7 +246,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-82-app-development-SRV-WIN-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2019-04-virtuoso-82-app-development-SRV-WIN#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-WIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-WIN.png> ;
 	skos:prefLabel "Virtuoso 8.2 Personal Application Development License For Windows (Server) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.2 Personal Application Development License  (expiring, 4 cores, 5 concurrent threads)" ;
 	schema:category "appdevelopment" ;
@@ -292,7 +292,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-WIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-WIN.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease82x#this> ;
 	schema:name "Software License : Virtuoso 8.2 Personal Application Development License  (expiring, 4 cores, 5 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -320,7 +320,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-82-app-development-SRV-LIN-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2019-04-virtuoso-82-app-development-SRV-LIN#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-LIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-LIN.png> ;
 	skos:prefLabel "Virtuoso 8.2 Personal Application Development License For Linux (Server) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.2 Personal Application Development License  (expiring, 4 cores, 5 concurrent threads)" ;
 	schema:category "appdevelopment" ;
@@ -366,7 +366,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-LIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-LIN.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease82x#this> ;
 	schema:name "Software License : Virtuoso 8.2 Personal Application Development License  (expiring, 4 cores, 5 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -394,7 +394,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer#http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer-unitprice%2FUnitPriceSpecification2019-04-virtuoso-82-app-development-SRV-MAC+-special-price%23this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/offer#http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Flicense%2FLicense-2019-04-virtuoso-82-app-development-SRV-MAC+%23this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-MAC.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-MAC.png> ;
 	skos:prefLabel "Virtuoso 8.2 Personal Application Development License For macOS (Server) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.2 Personal Application Development License  (expiring, 4 cores, 5 concurrent threads)" ;
 	schema:category "appdevelopment" ;
@@ -440,7 +440,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-MAC.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-MAC.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease82x#this> ;
 	schema:name "Software License : Virtuoso 8.2 Personal Application Development License  (expiring, 4 cores, 5 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -468,7 +468,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "1749.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-82-app-dev-workgroup-SRV-WIN-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2019-04-virtuoso-82-app-dev-workgroup-SRV-WIN#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-WIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-WIN.png> ;
 	skos:prefLabel "Virtuoso 8.2 Workgroup Application Development License For Windows (Server) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.2 Workgroup Application Development License  (expiring, 4 cores, 25 concurrent threads)" ;
 	schema:category "appdeveloperworkgroup" ;
@@ -514,7 +514,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-WIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-WIN.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease82x#this> ;
 	schema:name "Software License : Virtuoso 8.2 Workgroup Application Development License  (expiring, 4 cores, 25 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -542,7 +542,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "1749.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-82-app-dev-workgroup-SRV-LIN-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2019-04-virtuoso-82-app-dev-workgroup-SRV-LIN#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-LIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-LIN.png> ;
 	skos:prefLabel "Virtuoso 8.2 Workgroup Application Development License For Linux (Server) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.2 Workgroup Application Development License  (expiring, 4 cores, 25 concurrent threads)" ;
 	schema:category "appdeveloperworkgroup" ;
@@ -588,7 +588,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-LIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-LIN.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease82x#this> ;
 	schema:name "Software License : Virtuoso 8.2 Workgroup Application Development License  (expiring, 4 cores, 25 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -616,7 +616,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "1749.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-82-app-dev-workgroup-SRV-MAC-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2019-04-virtuoso-82-app-dev-workgroup-SRV-MAC#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-MAC.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-MAC.png> ;
 	skos:prefLabel "Virtuoso 8.2 Workgroup Application Development License For macOS (Server) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.2 Personal Application Development License  (expiring, 4 cores, 25 concurrent threads)" ;
 	schema:category "appdeveloperworkgroup" ;
@@ -662,7 +662,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-MAC.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-MAC.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease82x#this> ;
 	schema:name "Software License : Virtuoso 8.2 Personal Application Development License  (expiring, 4 cores, 25 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -690,7 +690,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "4999.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-82-app-dev-department-SRV-WIN-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2019-04-virtuoso-82-app-dev-department-SRV-WIN#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-WIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-WIN.png> ;
 	skos:prefLabel "Virtuoso 8.2 Department Level Application Development License For Windows (Server) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.2 Department Level Application Development License  (expiring, 4 cores, 75 concurrent threads)" ;
 	schema:category "appdeveloperdepartment" ;
@@ -736,7 +736,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-WIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-WIN.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease82x#this> ;
 	schema:name "Software License : Virtuoso 8.2 Department Level Application Development License  (expiring, 4 cores, 75 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -764,7 +764,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "4999.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-82-app-dev-department-SRV-LIN-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2019-04-virtuoso-82-app-dev-department-SRV-LIN#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-LIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-LIN.png> ;
 	skos:prefLabel "Virtuoso 8.2 Department Level Application Development License For Linux (Server) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.2 Department Level Application Development License  (expiring, 4 cores, 75 concurrent threads)" ;
 	schema:category "appdeveloperdepartment" ;
@@ -810,7 +810,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-LIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-LIN.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease82x#this> ;
 	schema:name "Software License : Virtuoso 8.2 Department Level Application Development License  (expiring, 4 cores, 75 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -838,7 +838,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "4999.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-82-app-dev-department-SRV-MAC-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2019-04-virtuoso-82-app-dev-department-SRV-MAC#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-MAC.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-MAC.png> ;
 	skos:prefLabel "Virtuoso 8.2 Department Level Application Development License For macOS (Server) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.2 Department Level Application Development License  (expiring, 4 cores, 75 concurrent threads)" ;
 	schema:category "appdeveloperdepartment" ;
@@ -884,7 +884,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-MAC.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-MAC.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease82x#this> ;
 	schema:name "Software License : Virtuoso 8.2 Department Level Application Development License  (expiring, 4 cores, 75 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;

--- a/Virtuoso-83-Offers-Licenses-Prices2019.ttl
+++ b/Virtuoso-83-Offers-Licenses-Prices2019.ttl
@@ -15,7 +15,7 @@
 	schema:price "249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-83-personal-WKS-WIN-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2020-04-virtuoso-83-personal-WKS-WIN#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-WIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-WIN.png> ;
 	skos:prefLabel "Virtuoso 8.3 Personal License For Windows (Workstation) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.3 Personal License  (expiring, 4 concurrent threads)" ;
 	schema:category "personal" ;
@@ -69,7 +69,7 @@ _:node1das6kevvx1 oplpro:hasFamily <http://data.openlinksw.com/oplweb/product_fa
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-WIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-WIN.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease83x#this> ;
 	schema:name "Software License : Virtuoso 8.3 Personal License  (expiring, 4 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -100,7 +100,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-83-personal-WKS-LIN-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2020-04-virtuoso-83-personal-WKS-LIN#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-LIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-LIN.png> ;
 	skos:prefLabel "Virtuoso 8.3 Personal License For Linux (Workstation) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.3 Personal License  (expiring, 4 concurrent threads)" ;
 	schema:category "personal" ;
@@ -148,7 +148,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-LIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-LIN.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease83x#this> ;
 	schema:name "Software License : Virtuoso 8.3 Personal License  (expiring, 4 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -176,7 +176,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-83-personal-WKS-MAC-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2020-04-virtuoso-83-personal-WKS-MAC#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-MAC.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-MAC.png> ;
 	skos:prefLabel "Virtuoso 8.3 Personal License For macOS (Workstation) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.3 Personal License  (expiring, 4 concurrent threads)" ;
 	schema:category "personal" ;
@@ -224,7 +224,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-MAC.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-2CON-4DB-MAC.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease83x#this> ;
 	schema:name "Software License : Virtuoso 8.3 Personal License  (expiring, 4 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -252,7 +252,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-83-app-development-SRV-WIN-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2020-04-virtuoso-83-app-development-SRV-WIN#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-WIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-WIN.png> ;
 	skos:prefLabel "Virtuoso 8.3 Personal Application Development License For Windows (Server) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.3 Personal Application Development License  (expiring, 4 cores, 5 concurrent threads)" ;
 	schema:category "appdevelopment" ;
@@ -300,7 +300,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-WIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-WIN.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease83x#this> ;
 	schema:name "Software License : Virtuoso 8.3 Personal Application Development License  (expiring, 4 cores, 5 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -328,7 +328,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-83-app-development-SRV-LIN-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2020-04-virtuoso-83-app-development-SRV-LIN#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-LIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-LIN.png> ;
 	skos:prefLabel "Virtuoso 8.3 Personal Application Development License For Linux (Server) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.3 Personal Application Development License  (expiring, 4 cores, 5 concurrent threads)" ;
 	schema:category "appdevelopment" ;
@@ -376,7 +376,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-LIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-LIN.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease83x#this> ;
 	schema:name "Software License : Virtuoso 8.3 Personal Application Development License  (expiring, 4 cores, 5 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -404,7 +404,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-83-app-development-SRV-MAC-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2020-04-virtuoso-83-app-development-SRV-MAC#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-MAC.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-MAC.png> ;
 	skos:prefLabel "Virtuoso 8.3 Personal Application Development License For macOS (Server) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.3 Personal Application Development License  (expiring, 4 cores, 5 concurrent threads)" ;
 	schema:category "appdevelopment" ;
@@ -452,7 +452,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-MAC.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-5CON-5DB-MAC.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease83x#this> ;
 	schema:name "Software License : Virtuoso 8.3 Personal Application Development License  (expiring, 4 cores, 5 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -480,7 +480,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "1749.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-83-app-dev-workgroup-SRV-WIN-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2020-04-virtuoso-83-app-dev-workgroup-SRV-WIN#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-WIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-WIN.png> ;
 	skos:prefLabel "Virtuoso 8.3 Workgroup Application Development License For Windows (Server) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.3 Workgroup Application Development License  (expiring, 4 cores, 25 concurrent threads)" ;
 	schema:category "appdeveloperworkgroup" ;
@@ -528,7 +528,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-WIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-WIN.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease83x#this> ;
 	schema:name "Software License : Virtuoso 8.3 Workgroup Application Development License  (expiring, 4 cores, 25 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -556,7 +556,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "1749.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-83-app-dev-workgroup-SRV-LIN-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2020-04-virtuoso-83-app-dev-workgroup-SRV-LIN#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-LIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-LIN.png> ;
 	skos:prefLabel "Virtuoso 8.3 Workgroup Application Development License For Linux (Server) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.3 Workgroup Application Development License  (expiring, 4 cores, 25 concurrent threads)" ;
 	schema:category "appdeveloperworkgroup" ;
@@ -604,7 +604,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-LIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-LIN.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease83x#this> ;
 	schema:name "Software License : Virtuoso 8.3 Workgroup Application Development License  (expiring, 4 cores, 25 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -632,7 +632,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "1749.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-83-app-dev-workgroup-SRV-MAC-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2020-04-virtuoso-83-app-dev-workgroup-SRV-MAC#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-MAC.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-MAC.png> ;
 	skos:prefLabel "Virtuoso 8.3 Workgroup Application Development License For macOS (Server) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.3 Personal Application Development License  (expiring, 4 cores, 25 concurrent threads)" ;
 	schema:category "appdeveloperworkgroup" ;
@@ -680,7 +680,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-MAC.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-25CON-25DB-MAC.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease83x#this> ;
 	schema:name "Software License : Virtuoso 8.3 Personal Application Development License  (expiring, 4 cores, 25 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -708,7 +708,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "4999.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-83-app-dev-department-SRV-WIN-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2020-04-virtuoso-83-app-dev-department-SRV-WIN#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-WIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-WIN.png> ;
 	skos:prefLabel "Virtuoso 8.3 Department Level Application Development License For Windows (Server) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.3 Department Level Application Development License  (expiring, 4 cores, 75 concurrent threads)" ;
 	schema:category "appdeveloperdepartment" ;
@@ -756,7 +756,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-WIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-WIN.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease83x#this> ;
 	schema:name "Software License : Virtuoso 8.3 Department Level Application Development License  (expiring, 4 cores, 75 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -784,7 +784,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "4999.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-83-app-dev-department-SRV-LIN-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2020-04-virtuoso-83-app-dev-department-SRV-LIN#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-LIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-LIN.png> ;
 	skos:prefLabel "Virtuoso 8.3 Department Level Application Development License For Linux (Server) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.3 Department Level Application Development License  (expiring, 4 cores, 75 concurrent threads)" ;
 	schema:category "appdeveloperdepartment" ;
@@ -832,7 +832,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-LIN.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-LIN.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease83x#this> ;
 	schema:name "Software License : Virtuoso 8.3 Department Level Application Development License  (expiring, 4 cores, 75 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
@@ -860,7 +860,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 	schema:price "4999.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification2019-04-virtuoso-83-app-dev-department-SRV-MAC-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/License-2020-04-virtuoso-83-app-dev-department-SRV-MAC#this> ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-MAC.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-MAC.png> ;
 	skos:prefLabel "Virtuoso 8.3 Department Level Application Development License For macOS (Server) Operating Systems" ;
 	schema:comment "Software License Offer: Virtuoso 8.3 Department Level Application Development License  (expiring, 4 cores, 75 concurrent threads)" ;
 	schema:category "appdeveloperdepartment" ;
@@ -908,7 +908,7 @@ Pricing is extremely competitive relative to competing alternatives when perform
 Enterprise Edition supports many optional functionality Modules; with the exception of the Elastic Cluster Module, the license in this offer enables all current Modules.
 
 Pricing is extremely competitive relative to competing alternatives when performance and capabilities are fully considered.""" ;
-	schema:image <http://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-MAC.png> ;
+	schema:image <https://virtuoso.openlinksw.com/images/OPL-VIRTOFFER-75CON-75DB-MAC.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease83x#this> ;
 	schema:name "Software License : Virtuoso 8.3 Department Level Application Development License  (expiring, 4 cores, 75 concurrent threads)" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;

--- a/Virtuoso8Releases.ttl
+++ b/Virtuoso8Releases.ttl
@@ -84,7 +84,7 @@ oplpro:hasRelease  <http://data.openlinksw.com/oplweb/product_release/VirtuosoRe
   dcterms:isVersionOf <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
   schema:version "8.0"^^xsd:decimal ;
   oplpro:versionText "8.0"^^xsd:string ;
-  schema:image <http://media-cache-ak0.pinimg.com/originals/52/de/1b/52de1b4e67a10efe19bc11eed1d52682.jpg> ;
+  schema:image <https://media-cache-ak0.pinimg.com/originals/52/de/1b/52de1b4e67a10efe19bc11eed1d52682.jpg> ;
   oplpro:hasFamily <http://data.openlinksw.com/oplweb/product_family/virtuoso#this>;
   schema:name "Virtuoso 8.0" ;
   wdrs:describedby  source:  ;
@@ -118,7 +118,7 @@ oplpro:hasRelease  <http://data.openlinksw.com/oplweb/product_release/VirtuosoRe
 				  dcterms:isVersionOf <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
 				  schema:version "8.0"^^xsd:decimal ;
 				  oplpro:versionText "8.0"^^xsd:string ;
-				  schema:image <http://media-cache-ak0.pinimg.com/originals/52/de/1b/52de1b4e67a10efe19bc11eed1d52682.jpg> ;
+				  schema:image <https://media-cache-ak0.pinimg.com/originals/52/de/1b/52de1b4e67a10efe19bc11eed1d52682.jpg> ;
 				  oplpro:hasFamily <http://data.openlinksw.com/oplweb/product_family/virtuoso#this>;
 				  schema:name "Virtuoso 8.0" ;
 				  wdrs:describedby  source:  ;
@@ -154,7 +154,7 @@ oplpro:hasRelease  <http://data.openlinksw.com/oplweb/product_release/VirtuosoRe
   dcterms:isVersionOf <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
   schema:version "8.1"^^xsd:decimal ;
   oplpro:versionText "8.1"^^xsd:string ;
-  schema:image <http://media-cache-ak0.pinimg.com/originals/52/de/1b/52de1b4e67a10efe19bc11eed1d52682.jpg> ;
+  schema:image <https://media-cache-ak0.pinimg.com/originals/52/de/1b/52de1b4e67a10efe19bc11eed1d52682.jpg> ;
   oplpro:hasFamily <http://data.openlinksw.com/oplweb/product_family/virtuoso#this>;
   schema:name "Virtuoso 8.1" ;
   wdrs:describedby  source:  ;
@@ -190,7 +190,7 @@ oplpro:hasRelease  <http://data.openlinksw.com/oplweb/product_release/VirtuosoRe
   dcterms:isVersionOf <http://data.openlinksw.com/oplweb/product/column-store-cl#this> ;
   schema:version "8.2"^^xsd:decimal ;
   oplpro:versionText "8.2"^^xsd:string ;
-  schema:image <http://media-cache-ak0.pinimg.com/originals/52/de/1b/52de1b4e67a10efe19bc11eed1d52682.jpg> ;
+  schema:image <https://media-cache-ak0.pinimg.com/originals/52/de/1b/52de1b4e67a10efe19bc11eed1d52682.jpg> ;
   oplpro:hasFamily <http://data.openlinksw.com/oplweb/product_family/virtuoso#this>;
   schema:name "Virtuoso 8.2" ;
   wdrs:describedby  source:  ;
@@ -234,9 +234,9 @@ oplpro:hasRelease  <http://data.openlinksw.com/oplweb/product_release/VirtuosoRe
 a schema:WebPage ;
 rdfs:label "Virtuoso 8.2 Docker Container Description Document" ;
 schema:about <http://data.openlinksw.com/oplweb/product/Virtuoso#this>, <http://data.openlinksw.com/oplweb/product_release/VirtuosoRelease82x#this> ;
-foaf:depiction <http://www.openlinksw.com/images/virtuoso-82-docker-container-1.png>, <http://www.openlinksw.com/images/virtuoso-82-docker-container-2.png>,
-               <http://www.openlinksw.com/images/virtuoso-82-docker-container-3.png>, <http://www.openlinksw.com/images/virtuoso-82-docker-container-4.png>,
-			   <http://www.openlinksw.com/images/virtuoso-82-docker-container-5.png>, <http://www.openlinksw.com/images/virtuoso-82-docker-container-6.png> ;
+foaf:depiction <https://www.openlinksw.com/images/virtuoso-82-docker-container-1.png>, <https://www.openlinksw.com/images/virtuoso-82-docker-container-2.png>,
+               <https://www.openlinksw.com/images/virtuoso-82-docker-container-3.png>, <https://www.openlinksw.com/images/virtuoso-82-docker-container-4.png>,
+			   <https://www.openlinksw.com/images/virtuoso-82-docker-container-5.png>, <https://www.openlinksw.com/images/virtuoso-82-docker-container-6.png> ;
 schema:url <http://hub.docker.com/r/openlink/virtuoso-closedsource-8/> ;
 dcterms:description """
 						One-click installation edition of a preconfigured Virtuoso 8.2 Multi-Model RDBMS instance. This particular 
@@ -266,7 +266,7 @@ is schema:about of <> .
 a schema:WebPage ;
 rdfs:label "Virtuoso 8.2 PAGO Edition Description Document" ;
 schema:about <http://data.openlinksw.com/oplweb/product/Virtuoso#this>, <http://data.openlinksw.com/oplweb/product/Virtuoso-ami-0175c4a749cf1741f#this> ;
-foaf:depiction <http://www.openlinksw.com/images/virtuoso-82-pago-ami-aws-marketplace.png> ;
+foaf:depiction <https://www.openlinksw.com/images/virtuoso-82-pago-ami-aws-marketplace.png> ;
 schema:url <https://aws.amazon.com/marketplace/pp/B011VMCZ8K/> ;
 dcterms:description """
 						One-click installation edition of a preconfigured Virtuoso 8.2 Multi-Model RDBMS instance. This particular 


### PR DESCRIPTION
…ontent warnings

Opening the shop page results in may mixed (insecure) content warning because the image urls are http rather than https